### PR TITLE
a

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash
 
     - name: Build Application
-      run: ./gradlew clean build
+      run: ./gradlew build
 
     - name: Build the Docker image
       run: docker build -t ${{ secrets.DOCKER_ADDRESS }}/${{ secrets.DOCKER_REPO }} .


### PR DESCRIPTION
Fix: 배포시 Spring Rest Docs가 생기지 않는 오류 해결 시도

./gradlew clan build는 static 디렉터리 내부에 Spring Rest Docs html이 생기지 않음